### PR TITLE
remove airbyte docs reference

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/source_chargebee/spec.json
+++ b/airbyte-integrations/connectors/source-chargebee/source_chargebee/spec.json
@@ -11,12 +11,12 @@
         "type": "string",
         "title": "Site",
         "description": "The site prefix for your Chargebee instance.",
-        "examples": ["airbyte-test"]
+        "examples": ["rudder-test"]
       },
       "site_api_key": {
         "type": "string",
         "title": "API Key",
-        "description": "Chargebee API Key. See the <a href=\"https://docs.airbyte.io/integrations/sources/chargebee\">docs</a> for more information on how to obtain this key.",
+        "description": "Chargebee API Key.",
         "examples": ["test_3yzfanAXF66USdWC9wQcM555DQJkSYoppu"],
         "airbyte_secret": true
       },

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
@@ -1,10 +1,14 @@
 {
-  "documentationUrl": "https://docs.airbyte.com/integrations/sources/google-ads",
+  "documentationUrl": "",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Google Ads Spec",
     "type": "object",
-    "required": ["credentials", "start_date", "customer_id"],
+    "required": [
+      "credentials",
+      "start_date",
+      "customer_id"
+    ],
     "additionalProperties": true,
     "properties": {
       "credentials": {
@@ -21,30 +25,30 @@
           "developer_token": {
             "type": "string",
             "title": "Developer Token",
-            "description": "Developer token granted by Google to use their APIs. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
+            "description": "Developer token granted by Google to use their APIs.",
             "airbyte_secret": true
           },
           "client_id": {
             "type": "string",
             "title": "Client ID",
-            "description": "The Client ID of your Google Ads developer application. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>"
+            "description": "The Client ID of your Google Ads developer application."
           },
           "client_secret": {
             "type": "string",
             "title": "Client Secret",
-            "description": "The Client Secret of your Google Ads developer application. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
+            "description": "The Client Secret of your Google Ads developer application.",
             "airbyte_secret": true
           },
           "access_token": {
             "type": "string",
             "title": "Access Token",
-            "description": "Access Token for making authenticated requests. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
+            "description": "Access Token for making authenticated requests.",
             "airbyte_secret": true
           },
           "refresh_token": {
             "type": "string",
             "title": "Refresh Token",
-            "description": "The token for obtaining a new access token. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>",
+            "description": "The token for obtaining a new access token.",
             "airbyte_secret": true
           }
         }
@@ -52,7 +56,7 @@
       "customer_id": {
         "title": "Customer ID",
         "type": "string",
-        "description": "Customer ID must be specified as a 10-digit number without dashes. More instruction on how to find this value in our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">docs</a>. Metrics streams like AdGroupAdReport cannot be requested for a manager account.",
+        "description": "Customer ID must be specified as a 10-digit number without dashes. Metrics streams like AdGroupAdReport cannot be requested for a manager account.",
         "order": 1
       },
       "start_date": {
@@ -60,7 +64,9 @@
         "title": "Start Date",
         "description": "UTC date and time in the format 2017-01-25. Any data before this date will not be replicated.",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-        "examples": ["2017-01-25"],
+        "examples": [
+          "2017-01-25"
+        ],
         "order": 2
       },
       "end_date": {
@@ -68,7 +74,9 @@
         "title": "End Date",
         "description": "UTC date and time in the format 2017-01-25. Any data after this date will not be replicated.",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-        "examples": ["2017-01-30"],
+        "examples": [
+          "2017-01-30"
+        ],
         "order": 6
       },
       "custom_queries": {
@@ -107,7 +115,9 @@
         "minimum": 0,
         "maximum": 1095,
         "default": 14,
-        "examples": [14],
+        "examples": [
+          14
+        ],
         "order": 5
       }
     }
@@ -115,13 +125,28 @@
   "authSpecification": {
     "auth_type": "oauth2.0",
     "oauth2Specification": {
-      "rootObject": ["credentials"],
-      "oauthFlowInitParameters": [
-        ["client_id"],
-        ["client_secret"],
-        ["developer_token"]
+      "rootObject": [
+        "credentials"
       ],
-      "oauthFlowOutputParameters": [["access_token"], ["refresh_token"]]
+      "oauthFlowInitParameters": [
+        [
+          "client_id"
+        ],
+        [
+          "client_secret"
+        ],
+        [
+          "developer_token"
+        ]
+      ],
+      "oauthFlowOutputParameters": [
+        [
+          "access_token"
+        ],
+        [
+          "refresh_token"
+        ]
+      ]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/spec.json
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/spec.json
@@ -1,5 +1,5 @@
 {
-  "documentationUrl": "https://docs.airbyte.io/integrations/sources/intercom",
+  "documentationUrl": "",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Source Intercom Spec",
@@ -17,7 +17,7 @@
       "access_token": {
         "title": "Access Token",
         "type": "string",
-        "description": "Access Token for making authenticated requests. See the <a href=\"https://docs.airbyte.io/integrations/sources/intercom\">docs</a> for more information on how to obtain this key manually.",
+        "description": "Access Token for making authenticated requests.",
         "airbyte_secret": true
       }
     }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/spec.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/spec.json
@@ -1,5 +1,5 @@
 {
-  "documentationUrl": "https://docs.airbyte.io/integrations/sources/iterable",
+  "documentationUrl": "",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Iterable Spec",
@@ -17,7 +17,7 @@
       "api_key": {
         "type": "string",
         "title": "API Key",
-        "description": "Iterable API Key. See the <a href=\"https://docs.airbyte.io/integrations/sources/iterable\">docs</a> for more information on how to obtain this key.",
+        "description": "Iterable API Key.",
         "airbyte_secret": true
       }
     }

--- a/airbyte-integrations/connectors/source-klaviyo/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-klaviyo/integration_tests/spec.json
@@ -1,13 +1,13 @@
 {
-  "documentationUrl": "https://docs.airbyte.io/integrations/sources/klaviyo",
-  "changelogUrl": "https://docs.airbyte.io/integrations/sources/klaviyo",
+  "documentationUrl": "",
+  "changelogUrl": "",
   "connectionSpecification": {
     "title": "Klaviyo Spec",
     "type": "object",
     "properties": {
       "api_key": {
         "title": "Api Key",
-        "description": "Klaviyo API Key. See our <a href=\"https://docs.airbyte.io/integrations/sources/klaviyo\">docs</a> if you need help finding this key.",
+        "description": "Klaviyo API Key.",
         "airbyte_secret": true,
         "type": "string"
       },

--- a/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/source.py
+++ b/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/source.py
@@ -18,7 +18,7 @@ class ConnectorConfig(BaseModel):
         title = "Klaviyo Spec"
 
     api_key: str = Field(
-        description='Klaviyo API Key. See our <a href="https://docs.airbyte.io/integrations/sources/klaviyo">docs</a> if you need help finding this key.',
+        description='Klaviyo API Key.',
         airbyte_secret=True,
     )
     start_date: str = Field(
@@ -69,8 +69,8 @@ class SourceKlaviyo(AbstractSource):
         required to run this integration.
         """
         return ConnectorSpecification(
-            documentationUrl="https://docs.airbyte.io/integrations/sources/klaviyo",
-            changelogUrl="https://docs.airbyte.io/integrations/sources/klaviyo",
+            documentationUrl="",
+            changelogUrl="",
             supportsIncremental=True,
             supported_destination_sync_modes=[DestinationSyncMode.append],
             connectionSpecification=ConnectorConfig.schema(),


### PR DESCRIPTION
## PR Description
> Remove any airbyte doc reference in fields description for supported source ( chargebee, intercom, iterable, klaviyo, google_ads )

## Notion ticket
> [Ticket link](https://www.notion.so/rudderstacks/d8ea6e5cd7b2481db207d6b239676688?v=a417c150dc2f4f989102ba3fbb4986fc&p=088a5e5691f34ce3abc4e1a6fcbb5413)
## Note
> We need to rebuild and publish images for chargebee, intercom, iterable, klaviyo, google_ads and also update the image versions of each source in source-definiton options
