### PR TITLE
remove api authentication from hubspot

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/api.py
@@ -126,20 +126,13 @@ class API:
 
     def __init__(self, credentials: Mapping[str, Any]):
         self._session = requests.Session()
-        credentials_title = credentials.get("credentials_title")
-
-        if credentials_title == "OAuth Credentials":
-            self._session.auth = Oauth2Authenticator(
-                token_refresh_endpoint=self.BASE_URL + "/oauth/v1/token",
-                client_id=credentials["client_id"],
-                client_secret=credentials["client_secret"],
-                refresh_token=credentials["refresh_token"],
-            )
-        elif credentials_title == "API Key Credentials":
-            self._session.params["hapikey"] = credentials.get("api_key")
-        else:
-            raise Exception("No supported `credentials_title` specified. See spec.json for references")
-
+        self._session.auth = Oauth2Authenticator(
+                            token_refresh_endpoint=self.BASE_URL + "/oauth/v1/token",
+                            client_id=credentials["client_id"],
+                            client_secret=credentials["client_secret"],
+                            refresh_token=credentials["refresh_token"],
+                        )
+        
         self._session.headers = {
             "Content-Type": "application/json",
             "User-Agent": self.USER_AGENT,

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/spec.json
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/spec.json
@@ -1,10 +1,13 @@
 {
-  "documentationUrl": "https://docs.airbyte.io/integrations/sources/hubspot",
+  "documentationUrl": "https://developers.hubspot.com/docs/api/overview",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "HubSpot Source Spec",
     "type": "object",
-    "required": ["start_date", "credentials"],
+    "required": [
+      "start_date",
+      "credentials"
+    ],
     "additionalProperties": true,
     "properties": {
       "start_date": {
@@ -12,86 +15,64 @@
         "title": "Start Date",
         "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
         "description": "UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated.",
-        "examples": ["2017-01-25T00:00:00Z"]
+        "examples": [
+          "2017-01-25T00:00:00Z"
+        ]
       },
       "credentials": {
-        "title": "Authentication mechanism",
-        "description": "Choose how to authenticate to HubSpot.",
         "type": "object",
-        "oneOf": [
-          {
-            "type": "object",
-            "title": "Authenticate via HubSpot (OAuth)",
-            "required": [
-              "client_id",
-              "client_secret",
-              "refresh_token",
-              "credentials_title"
-            ],
-            "properties": {
-              "credentials_title": {
-                "type": "string",
-                "title": "Credentials Title",
-                "description": "Name of the credentials set",
-                "const": "OAuth Credentials",
-                "enum": ["OAuth Credentials"],
-                "default": "OAuth Credentials",
-                "order": 0
-              },
-              "client_id": {
-                "title": "Client ID",
-                "description": "The Client ID of your HubSpot developer application. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\">docs</a> if you need help finding this id.",
-                "type": "string",
-                "examples": ["123456789000"]
-              },
-              "client_secret": {
-                "title": "Client Secret",
-                "description": "The Client Secret of your HubSpot developer application. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\">docs</a> if you need help finding this secret.",
-                "type": "string",
-                "examples": ["secret"],
-                "airbyte_secret": true
-              },
-              "refresh_token": {
-                "title": "Refresh Token",
-                "description": "Refresh Token to renew the expired Access Token. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\">docs</a> if you need help generating the token.",
-                "type": "string",
-                "examples": ["refresh_token"],
-                "airbyte_secret": true
-              }
-            }
+        "title": "HubSpot Credentials",
+        "properties": {
+          "client_id": {
+            "title": "Client ID",
+            "description": "The Client ID of your HubSpot developer application.",
+            "type": "string",
+            "examples": [
+              "123456789000"
+            ]
           },
-          {
-            "type": "object",
-            "title": "API key",
-            "required": ["api_key", "credentials_title"],
-            "properties": {
-              "credentials_title": {
-                "type": "string",
-                "title": "Credentials title",
-                "description": "Name of the credentials set",
-                "const": "API Key Credentials",
-                "enum": ["API Key Credentials"],
-                "default": "API Key Credentials",
-                "order": 0
-              },
-              "api_key": {
-                "title": "API key",
-                "description": "HubSpot API Key. See our <a href=\"https://docs.airbyte.io/integrations/sources/hubspot\">docs</a> if you need help finding this key.",
-                "type": "string",
-                "airbyte_secret": true
-              }
-            }
+          "client_secret": {
+            "title": "Client Secret",
+            "description": "The Client Secret of your HubSpot developer application.",
+            "type": "string",
+            "examples": [
+              "secret"
+            ],
+            "airbyte_secret": true
+          },
+          "refresh_token": {
+            "title": "Refresh Token",
+            "description": "Refresh Token to renew the expired Access Token.",
+            "type": "string",
+            "examples": [
+              "refresh_token"
+            ],
+            "airbyte_secret": true
           }
-        ]
+        }
       }
     }
   },
   "authSpecification": {
     "auth_type": "oauth2.0",
     "oauth2Specification": {
-      "rootObject": ["credentials", "0"],
-      "oauthFlowInitParameters": [["client_id"], ["client_secret"]],
-      "oauthFlowOutputParameters": [["refresh_token"]]
+      "rootObject": [
+        "credentials",
+        "0"
+      ],
+      "oauthFlowInitParameters": [
+        [
+          "client_id"
+        ],
+        [
+          "client_secret"
+        ]
+      ],
+      "oauthFlowOutputParameters": [
+        [
+          "refresh_token"
+        ]
+      ]
     }
   }
 }


### PR DESCRIPTION
## Description
> Hubspot support 2 types of authentication 
1. OAuth
2. API key
We removed API key support because of the complexity that requires in `webapp` to support both.