### PR TITLE
Remove airbyte reference from field descriptions

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/spec.json
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/spec.json
@@ -1,5 +1,5 @@
 {
-  "documentationUrl": "https://docs.airbyte.io/integrations/sources/zendesk-support",
+  "documentationUrl": "https://www.zendesk.com/service/ticketing-system/documentation",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Source Zendesk Support Spec",
@@ -28,7 +28,7 @@
             "title": "OAuth2.0",
             "type": "object",
             "required": ["access_token"],
-            "additionalProperties": true,
+            "additionalProperties": false,
             "properties": {
               "credentials": {
                 "type": "string",
@@ -38,7 +38,7 @@
               "access_token": {
                 "type": "string",
                 "title": "Access Token",
-                "description": "The value of the API token generated. See the <a href=\"https://docs.airbyte.io/integrations/sources/zendesk-support\">docs</a> for more information.",
+                "description": "The value of the API token generated.",
                 "airbyte_secret": true
               }
             }
@@ -47,7 +47,7 @@
             "title": "API Token",
             "type": "object",
             "required": ["email", "api_token"],
-            "additionalProperties": true,
+            "additionalProperties": false,
             "properties": {
               "credentials": {
                 "type": "string",
@@ -62,7 +62,7 @@
               "api_token": {
                 "title": "API Token",
                 "type": "string",
-                "description": "The value of the API token generated. See the <a href=\"https://docs.airbyte.com/integrations/sources/zendesk-support#setup-guide\">docs</a> for more information.",
+                "description": "The value of the API token generated.",
                 "airbyte_secret": true
               }
             }


### PR DESCRIPTION
## Description of the change

> Remove airbyte reference from field descriptions and set `additionalProperties` to false 

## Notion Link

> [Notion Link](https://www.notion.so/rudderstacks/d8ea6e5cd7b2481db207d6b239676688?v=a417c150dc2f4f989102ba3fbb4986fc&p=63cf4fef966a46deba50cbc795b72801&pm=c)

