### PR TITLE
fix: adds correct primary keys for salesforce resource

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
@@ -173,6 +173,11 @@ UNSUPPORTED_FILTERING_STREAMS = [
     "UriEvent",
 ]
 
+RESOURCE_PRIMARY_KEY_MAP = {
+    "PlatformEventUsageMetric": None, # PlatformEventUsageMetric does not have a primary key
+    "FormulaFunctionAllowedType": "DurableId", # https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_formulafunctionallowedtype.htm
+}
+
 
 class Salesforce:
     logger = AirbyteLogger()
@@ -323,10 +328,14 @@ class Salesforce:
         return stream_schemas
 
     @staticmethod
-    def get_pk_and_replication_key(json_schema: Mapping[str, Any]) -> Tuple[Optional[str], Optional[str]]:
+    def get_pk_and_replication_key(source_name, json_schema: Mapping[str, Any]) -> Tuple[Optional[str], Optional[str]]:
         fields_list = json_schema.get("properties", {}).keys()
 
         pk = "Id" if "Id" in fields_list else None
+        # for some resources, primary key is not Id
+        # still salesforce sends Id field in response
+        # We are overriding it with the correct primary key, defined in the mapping
+        pk = RESOURCE_PRIMARY_KEY_MAP.get(source_name, pk)
         replication_key = None
         if "SystemModstamp" in fields_list:
             replication_key = "SystemModstamp"

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/source.py
@@ -66,7 +66,7 @@ class SourceSalesforce(AbstractSource):
                 full_refresh, incremental = BulkSalesforceStream, BulkIncrementalSalesforceStream
 
             json_schema = stream_properties.get(stream_name, {})
-            pk, replication_key = sf_object.get_pk_and_replication_key(json_schema)
+            pk, replication_key = sf_object.get_pk_and_replication_key(stream_name, json_schema)
             streams_kwargs.update(dict(sf_api=sf_object, pk=pk, stream_name=stream_name, schema=json_schema, authenticator=authenticator))
             if replication_key and stream_name not in UNSUPPORTED_FILTERING_STREAMS:
                 streams.append(incremental(**streams_kwargs, replication_key=replication_key, start_date=config.get("start_date")))


### PR DESCRIPTION
## What
Adds custom primary key for
`PlatformEventUsageMetric`
`FormulaFunctionAllowedType`
---
## Some background:
Salesforce sends a field called `Id`, which Airbyte treats as the default primary key.
Id is not necessarily supposed to act as a primary key. As an example, for the above two resources, the Id field is the same for all the rows.
Since Id is the same and we treat whichever field Airbyte asks us to treat as pk, we send the same values under Id, and the warehouse dedupes the entire batch into 1 row, resulting in data loss.
