### PR TITLE
feat: add support for updating records for stripe

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -163,17 +163,15 @@ class IncrementalStripeStreamWithUpdates(IncrementalStripeStream):
     """
         This is a base class for incremental streams that support updates using the events API
         In first sync it will not get any updates as the records are already updated
-        After first sync it will get all updates for the last 30 days starting from the first sync date
-        and then it will use the date of the last event as state
+        After first sync it will get all updates starting from date of the last sync
     """
     event_types = None
     update_field = "event_created"
 
     def read_records(self,stream_slice, stream_state, **kwargs) -> Iterable[Mapping[str, Any]]:
-        # Get the records 
-        newRecordsIDList =[]
         # If this is not the first sync also get the updates
         if stream_state.get(self.cursor_field) is not None: 
+            newRecordsIDList =[]
             for record in super().read_records(stream_slice=stream_slice, stream_state=stream_state, **kwargs):
                 newRecordsIDList.append(record[self.get_record_id_key(record)])
                 yield record
@@ -192,7 +190,7 @@ class IncrementalStripeStreamWithUpdates(IncrementalStripeStream):
                 # Skip updates for new records
                 if recordId in newRecords:
                     continue
-                if updatedRecords.get(recordId) is None:
+                if recordId not in updatedRecords:
                     updatedRecords[recordId] = event 
                 # If the event is newer than the one we have in updatedRecords
                 # replace it with the new one

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -198,7 +198,7 @@ class IncrementalStripeStreamWithUpdates(IncrementalStripeStream):
             durationInDaysFromLastSync = duration.days
         # If last state is not present or the main sync didn't complete or the last sync was more than 30 days ago
         # Fetch data from original stream else fetch data from events
-        shouldResetState = durationInDaysFromLastSync > 30
+        shouldResetState = durationInDaysFromLastSync >= 30
         return hasState == False or self.completed is False or shouldResetState
     def read_records(self, stream_slice, stream_state, **kwargs) -> Iterable[Mapping[str, Any]]:
         shouldFetchFromOriginalResource = self.shouldFetchFromOriginalResource(stream_state)


### PR DESCRIPTION
## Description
Add support for getting updates for incremental syncs for the following `stripe` resources using the event API
1. charges
2. customers
3. disputes
4. invoices
5. invoice_items
6. plans
7. products
8. subscriptions
9. transfers

## Docs
> https://www.notion.so/rudderstacks/Stripe-updated-records-d1df062071b848cb87966c1b2d56f8a1
> https://www.notion.so/rudderstacks/Stripe-APIs-and-Correct-ETL-WIP-3914e964880e43cfa5e4e09535fa8e1a


## Ticket
> [Stripe: Add support for getting updated records](https://www.notion.so/rudderstacks/d8ea6e5cd7b2481db207d6b239676688?v=799e76e4eabd45b3ad80c87fdebdb765&p=2e0568e15419421c99d926677107cc27&pm=c)
