### PR TITLE
fix: exclude TaskWhoRelation from BULK API list

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py
@@ -150,7 +150,8 @@ UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS = [
     "TaskStatus",
     "UndecidedEventRelation",
     "WorkOrderLineItemStatus",
-    "WorkOrderStatus"
+    "WorkOrderStatus",
+    "TaskWhoRelation"
 ]
 
 UNSUPPORTED_FILTERING_STREAMS = [


### PR DESCRIPTION
## What
fix: exclude TaskWhoRelation from BULK API list
Squadcast Alert - https://app.squadcast.com/incident/636b0f92ae328f3139d90312

## How
Add TaskWhoRelation to UNSUPPORTED_BULK_API_SALESFORCE_OBJECTS list


## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
Are there any breaking changes? What is the end result perceived by the user? If yes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.

## Pre-merge Checklist
Expand the relevant checklist and delete the others.
