### PR TITLE
fix: log type to warning for intercom scroll API

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/source_intercom/source.py
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/source.py
@@ -319,7 +319,7 @@ class Companies(IncrementalIntercomStream):
         if self.check_exists_scroll(response):
             self._backoff_count += 1
             if self.need_use_standard():
-                self.logger.warn(
+                self.logger.warning(
                     "Can't create a new scroll request within an minute or scroll param was expired. "
                     "Let's try to use a standard non-scroll endpoint."
                 )

--- a/airbyte-integrations/connectors/source-intercom/source_intercom/source.py
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/source.py
@@ -319,7 +319,7 @@ class Companies(IncrementalIntercomStream):
         if self.check_exists_scroll(response):
             self._backoff_count += 1
             if self.need_use_standard():
-                self.logger.error(
+                self.logger.warn(
                     "Can't create a new scroll request within an minute or scroll param was expired. "
                     "Let's try to use a standard non-scroll endpoint."
                 )


### PR DESCRIPTION
## What
Companies stream has a fallback if scroll API cannot be accessed.
While falling back, airbyte logs the message as an error, causing the termination of the task in RS.