### PR TITLE
fix: settings stream response if stream unavailable

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/source_freshdesk/streams.py
+++ b/airbyte-integrations/connectors/source-freshdesk/source_freshdesk/streams.py
@@ -250,8 +250,6 @@ class Settings(FreshdeskStream):
     def path(self, **kwargs) -> str:
         return "settings/helpdesk"
 
-    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
-        yield response.json()
 
 # Skills api keeps failing with 404 error maybe because this resource is available only for enterprise accounts users.
 # Not sure as the documentation is not clear about it. Disabling it for now.


### PR DESCRIPTION
## What
Fixes Settings stream response in case stream is unavailable. 

## How
Remove parse_response function for settings, unavailable stream handled in parse_response for FreshdeskStream
