### PR TITLE
chore: make zendesk support connector to save state frequently

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/streams.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/streams.py
@@ -467,6 +467,13 @@ class SourceZendeskIncrementalExportStream(SourceZendeskSupportCursorPaginationS
     response_list_name: str = None
     sideload_param: str = None
 
+    @property
+    def state_checkpoint_interval(self) -> Optional[int]:
+        """
+        Will allow the connector send state messages more frequent and not only at the end of the sync.
+        """
+        return 1000
+
     @staticmethod
     def check_start_time_param(requested_start_time: int, value: int = 1):
         """


### PR DESCRIPTION
We need to save states more frequently. We save the state only at the end of the sync process.

[ticket](https://www.notion.so/rudderstacks/Fix-Hubspot-Oauth-Role-to-singer-hubspot-8125c7f7972e435b9760a88399fd4a6e?pvs=4)