### PR TITLE
fix: allow additional properties in spec Zendesk support

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/spec.json
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/spec.json
@@ -29,7 +29,7 @@
             "title": "OAuth2.0",
             "type": "object",
             "required": ["access_token"],
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "credentials": {
                 "type": "string",

--- a/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/spec.json
+++ b/airbyte-integrations/connectors/source-zendesk-support/source_zendesk_support/spec.json
@@ -48,7 +48,7 @@
             "title": "API Token",
             "type": "object",
             "required": ["email", "api_token"],
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
               "credentials": {
                 "type": "string",


### PR DESCRIPTION
Revert the additionalProperties to true as Airbyte has. It causes issues with the front end. 
![Screenshot 2023-03-28 at 1 33 01 PM](https://user-images.githubusercontent.com/1304376/228209693-a8dbf604-cf27-438a-a402-33d66e8bdbc8.png)

