### PR TITLE
fix: rename record id to stripe id

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -240,7 +240,7 @@ class IncrementalStripeStreamWithUpdates(IncrementalStripeStream):
          Sets the primary_key of the record to a new field (i.e. {subscription_id: "..."}) and replace
          the actual id with a unique value
         """
-        record["stripeId"] = record[self.primary_key]
+        record["stripe_id"] = record[self.primary_key]
         # Change the original id to random uuid to avoid warehouse deduplication
         record[self.primary_key] = uuid.uuid1()
 
@@ -513,13 +513,13 @@ class StripeSubStream(StripeStream, ABC):
         # get next pages
         items_next_pages = []
         if items_obj.get("has_more") and items:
-            stream_slice = {self.parent_id: parent_record["stripeId"], "starting_after": items[-1]["id"]}
+            stream_slice = {self.parent_id: parent_record["stripe_id"], "starting_after": items[-1]["id"]}
             items_next_pages = super().read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice, **kwargs)
 
         for item in chain(items, items_next_pages):
             if self.add_parent_id:
                 # add reference to parent object when item doesn't have it already
-                item[self.parent_id] = parent_record["stripeId"]
+                item[self.parent_id] = parent_record["stripe_id"]
             yield item
 
 

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -25,6 +25,7 @@ STRIPE_ERROR_CODES: List = [
     "account_invalid",
 ]
 
+STRIPE_RECORD_ID = "stripe_record_id"
 
 class StripeStream(HttpStream, ABC):
     url_base = "https://api.stripe.com/v1/"
@@ -240,7 +241,7 @@ class IncrementalStripeStreamWithUpdates(IncrementalStripeStream):
          Sets the primary_key of the record to a new field (i.e. {subscription_id: "..."}) and replace
          the actual id with a unique value
         """
-        record["stripe_id"] = record[self.primary_key]
+        record[STRIPE_RECORD_ID] = record[self.primary_key]
         # Change the original id to random uuid to avoid warehouse deduplication
         record[self.primary_key] = uuid.uuid1()
 
@@ -513,13 +514,13 @@ class StripeSubStream(StripeStream, ABC):
         # get next pages
         items_next_pages = []
         if items_obj.get("has_more") and items:
-            stream_slice = {self.parent_id: parent_record["stripe_id"], "starting_after": items[-1]["id"]}
+            stream_slice = {self.parent_id: parent_record[STRIPE_RECORD_ID], "starting_after": items[-1]["id"]}
             items_next_pages = super().read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice, **kwargs)
 
         for item in chain(items, items_next_pages):
             if self.add_parent_id:
                 # add reference to parent object when item doesn't have it already
-                item[self.parent_id] = parent_record["stripe_id"]
+                item[self.parent_id] = parent_record[STRIPE_RECORD_ID]
             yield item
 
 

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -240,7 +240,7 @@ class IncrementalStripeStreamWithUpdates(IncrementalStripeStream):
          Sets the primary_key of the record to a new field (i.e. {subscription_id: "..."}) and replace
          the actual id with a unique value
         """
-        record["stripe_id"] = record[self.primary_key]
+        record["stripeId"] = record[self.primary_key]
         # Change the original id to random uuid to avoid warehouse deduplication
         record[self.primary_key] = uuid.uuid1()
 
@@ -513,13 +513,13 @@ class StripeSubStream(StripeStream, ABC):
         # get next pages
         items_next_pages = []
         if items_obj.get("has_more") and items:
-            stream_slice = {self.parent_id: parent_record["stripe_id"], "starting_after": items[-1]["id"]}
+            stream_slice = {self.parent_id: parent_record["stripeId"], "starting_after": items[-1]["id"]}
             items_next_pages = super().read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice, **kwargs)
 
         for item in chain(items, items_next_pages):
             if self.add_parent_id:
                 # add reference to parent object when item doesn't have it already
-                item[self.parent_id] = parent_record["stripe_id"]
+                item[self.parent_id] = parent_record["stripeId"]
             yield item
 
 

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py
@@ -240,7 +240,7 @@ class IncrementalStripeStreamWithUpdates(IncrementalStripeStream):
          Sets the primary_key of the record to a new field (i.e. {subscription_id: "..."}) and replace
          the actual id with a unique value
         """
-        record["record_id"] = record[self.primary_key]
+        record["stripe_id"] = record[self.primary_key]
         # Change the original id to random uuid to avoid warehouse deduplication
         record[self.primary_key] = uuid.uuid1()
 
@@ -513,13 +513,13 @@ class StripeSubStream(StripeStream, ABC):
         # get next pages
         items_next_pages = []
         if items_obj.get("has_more") and items:
-            stream_slice = {self.parent_id: parent_record["record_id"], "starting_after": items[-1]["id"]}
+            stream_slice = {self.parent_id: parent_record["stripe_id"], "starting_after": items[-1]["id"]}
             items_next_pages = super().read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice, **kwargs)
 
         for item in chain(items, items_next_pages):
             if self.add_parent_id:
                 # add reference to parent object when item doesn't have it already
-                item[self.parent_id] = parent_record["record_id"]
+                item[self.parent_id] = parent_record["stripe_id"]
             yield item
 
 


### PR DESCRIPTION
## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
