### PR TITLE
ETL-114 fix.fb_ads_validation

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -88,7 +88,7 @@ class SourceFacebookMarketing(AbstractSource):
             api = API(account_id=config.account_id, access_token=config.access_token)
             logger.info(f"Select account {api.account}")
         except (requests.exceptions.RequestException, ValidationError, FacebookAPIException) as e:
-            return False, e
+            return False, f"error: {repr(e)}"
 
         # make sure that we have valid combination of "action_breakdowns" and "breakdowns" parameters
         for stream in self.get_custom_insights_streams(api, config):


### PR DESCRIPTION
fix: returns error message instead of exception object while validating account
