### PR TITLE
fix: adds primary key where missing

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml
@@ -286,12 +286,14 @@ definitions:
     $ref: "#/definitions/stream_incremental_search"
     $parameters:
       name: "contacts"
+      primary_key: "id"
       path: "contacts/search"
       page_size: 150
   conversations:
     $ref: "#/definitions/stream_incremental_search"
     $parameters:
       name: "conversations"
+      primary_key: "id"
       path: "conversations/search"
       data_field: "conversations"
       page_size: 150


### PR DESCRIPTION
## What
Primary key missing from catalog (https://linear.app/rudderstack/issue/ETL-135/add-primary-key-for-conversations-resource-intercom)

## Testing
<img width="541" alt="Screenshot 2023-09-15 at 11 40 51 AM" src="https://github.com/rudderlabs/airbyte/assets/110388330/2129e3af-7ce6-4b82-986e-7af8aee6c356">
<img width="364" alt="Screenshot 2023-09-15 at 11 41 13 AM" src="https://github.com/rudderlabs/airbyte/assets/110388330/a023c7b8-c329-4f07-83b4-a41017d3f362">
