### PR TITLE
fix: google ads custom query validation

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/custom_query_stream.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/custom_query_stream.py
@@ -106,7 +106,10 @@ class IncrementalCustomQuery(CustomQueryMixin, IncrementalGoogleAdsStream):
             query = query.append_field("segments.date")
         condition = f"segments.date BETWEEN '{start_date}' AND '{end_date}'"
         if query.where:
-            return query.set_where(query.where + " AND " + condition)
+            if "segments.date" not in query.where:
+                return query.set_where(query.where + " AND " + condition)
+            else:
+                return query.set_where(query.where)
         return query.set_where(condition)
 
 


### PR DESCRIPTION
## What
* fix google ads custom query validation if segments.date already present in query
