### PR TITLE
fix: update api version to 2023-07

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/source.py
@@ -30,7 +30,7 @@ from .utils import ShopifyRateLimiter as limiter
 
 class ShopifyStream(HttpStream, ABC):
     # Latest Stable Release
-    api_version = "2022-10"
+    api_version = "2023-07"
     # Page size
     limit = 250
     # Define primary key as sort key for full_refresh, or very first sync for incremental_refresh


### PR DESCRIPTION
## What
* Handle api version being deprecated

## How
* Update the api version to latest one

