### PR TITLE
feat.etl-304.addClientSecretInSpecs

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py
@@ -48,6 +48,7 @@ class MyFacebookAdsApi(FacebookAdsApi):
     # Insights async jobs throttle
     _ads_insights_throttle: Throttle
     _access_token = None
+    _app_secret = None
 
     @property
     def ads_insights_throttle(self) -> Throttle:
@@ -98,9 +99,12 @@ class MyFacebookAdsApi(FacebookAdsApi):
         cls._access_token = access_token
 
     @classmethod
+    def set_app_secret(cls, app_secret):
+        cls._app_secret = app_secret
+    @classmethod
     def reset_session(cls):
         logger.info("resetting session after sleep")
-        api = MyFacebookAdsApi.init(access_token=MyFacebookAdsApi._access_token, crash_log=False)
+        api = MyFacebookAdsApi.init(access_token=MyFacebookAdsApi._access_token, app_secret=MyFacebookAdsApi._app_secret, crash_log=False)
         FacebookAdsApi.set_default_api(api)
 
     def _compute_pause_interval(self, usage, pause_interval):
@@ -193,11 +197,13 @@ class MyFacebookAdsApi(FacebookAdsApi):
 class API:
     """Simple wrapper around Facebook API"""
 
-    def __init__(self, account_id: str, access_token: str):
+    def __init__(self, account_id: str, access_token: str, app_secret: str = None):
         self._account_id = account_id
         # design flaw in MyFacebookAdsApi requires such strange set of new default api instance
-        self.api = MyFacebookAdsApi.init(access_token=access_token, crash_log=False)
+        self.api = MyFacebookAdsApi.init(access_token=access_token, app_secret=app_secret, crash_log=False)
         MyFacebookAdsApi.set_access_token(access_token)
+        if app_secret:
+            MyFacebookAdsApi.set_app_secret(app_secret=app_secret)
         FacebookAdsApi.set_default_api(self.api)
 
     @cached_property

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -85,7 +85,7 @@ class SourceFacebookMarketing(AbstractSource):
             if config.end_date < config.start_date:
                 return False, "end_date must be equal or after start_date."
 
-            api = API(account_id=config.account_id, access_token=config.access_token)
+            api = API(account_id=config.account_id, access_token=config.access_token, app_secret=config.client_secret)
             logger.info(f"Select account {api.account}")
         except (requests.exceptions.RequestException, ValidationError, FacebookAPIException) as e:
             return False, f"error: {repr(e)}"
@@ -110,7 +110,7 @@ class SourceFacebookMarketing(AbstractSource):
         config.start_date = validate_start_date(config.start_date)
         config.end_date = validate_end_date(config.start_date, config.end_date)
 
-        api = API(account_id=config.account_id, access_token=config.access_token)
+        api = API(account_id=config.account_id, access_token=config.access_token, app_secret=config.client_secret)
 
         insights_args = dict(
             api=api, start_date=config.start_date, end_date=config.end_date, insights_lookback_window=config.insights_lookback_window

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -180,4 +180,5 @@ class ConnectorConfig(BaseConfig):
 
     credentials: Credentials = Field(
         airbyte_hidden=True,
+        airbyte_secret=True,
     )

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -75,22 +75,6 @@ class InsightConfig(BaseModel):
         default=28,
     )
 
-
-class Credentials(BaseModel):
-
-    class Config:
-        title = "Credentials"
-
-    client_id: Optional[str] = Field(
-        description="The Client Id for your OAuth app",
-        airbyte_secret=True,
-    )
-
-    client_secret: Optional[str] = Field(
-        description="The Client Secret for your OAuth app",
-        airbyte_secret=True,
-    )
-
 class ConnectorConfig(BaseConfig):
     """Connector config"""
 
@@ -178,7 +162,12 @@ class ConnectorConfig(BaseConfig):
         airbyte_hidden=True,
     )
 
-    credentials: Credentials = Field(
-        airbyte_hidden=True,
+    client_id: Optional[str] = Field(
+        description="The Client Id for your OAuth app",
+        airbyte_secret=True,
+    )
+
+    client_secret: Optional[str] = Field(
+        description="The Client Secret for your OAuth app",
         airbyte_secret=True,
     )

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -160,12 +160,5 @@ class ConnectorConfig(BaseConfig):
     action_breakdowns_allow_empty: bool = Field(
         description="Allows action_breakdowns to be an empty list",
         default=True,
-        order=10,
         airbyte_hidden=True,
-    )
-
-    client_secret: str = Field(
-        description="app_secret",
-        order=11,
-        airbyte_secret=True,
     )

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -160,5 +160,12 @@ class ConnectorConfig(BaseConfig):
     action_breakdowns_allow_empty: bool = Field(
         description="Allows action_breakdowns to be an empty list",
         default=True,
+        order=10,
         airbyte_hidden=True,
+    )
+
+    client_secret: str = Field(
+        description="app_secret",
+        order=11,
+        airbyte_secret=True,
     )

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -76,6 +76,21 @@ class InsightConfig(BaseModel):
     )
 
 
+class Credentials(BaseModel):
+
+    class Config:
+        title = "Credentials"
+
+    client_id: Optional[str] = Field(
+        description="The Client Id for your OAuth app",
+        airbyte_secret=True,
+    )
+
+    client_secret: Optional[str] = Field(
+        description="The Client Secret for your OAuth app",
+        airbyte_secret=True,
+    )
+
 class ConnectorConfig(BaseConfig):
     """Connector config"""
 
@@ -160,5 +175,9 @@ class ConnectorConfig(BaseConfig):
     action_breakdowns_allow_empty: bool = Field(
         description="Allows action_breakdowns to be an empty list",
         default=True,
+        airbyte_hidden=True,
+    )
+
+    credentials: Credentials = Field(
         airbyte_hidden=True,
     )


### PR DESCRIPTION
Add client_id and client_secret as config parameters for Facebook marketing connector. 
We will use client_sercet to hash the access token and add [app_secretproof](https://developers.facebook.com/docs/graph-api/securing-requests%20/). This may prevent access tokens from getting expired.  Blendo uses it and access tokens don't get expired. 