### PR TITLE
chore: update repository-dispatch for SEC-58 compliance

### DIFF
--- a/.github/workflows/notify-on-push-to-master.yml
+++ b/.github/workflows/notify-on-push-to-master.yml
@@ -19,8 +19,10 @@ jobs:
           egress-policy: audit
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2.1.2
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
+          # PAT required: target repository airbytehq/airbyte-cloud is in external org (airbytehq)
+          # GitHub App tokens only work within the organization where the App is installed
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           repository: airbytehq/airbyte-cloud
           event-type: oss-push-to-master


### PR DESCRIPTION
## Summary
- Upgrade `peter-evans/repository-dispatch` from v2.1.2 to v3.0.0
- Document PAT exception with inline comments explaining why GitHub App token cannot be used

## PAT Exception Rationale
The target repository `airbytehq/airbyte-cloud` is in an **external organization** (airbytehq, not rudderlabs). GitHub App tokens only have permissions within the organization where the App is installed. Since the RudderStack GitHub App is not installed on the `airbytehq` organization, a Personal Access Token (PAT) is required for cross-organization repository dispatch.

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Verify action still triggers successfully after version upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)